### PR TITLE
[FEAT] 월간 및 연간 데이터 수집

### DIFF
--- a/src/main/java/com/yachaerang/yachaerangbatch/configuration/job/DailyPriceJobConfig.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/configuration/job/DailyPriceJobConfig.java
@@ -1,5 +1,6 @@
 package com.yachaerang.yachaerangbatch.configuration.job;
 
+import com.yachaerang.yachaerangbatch.configuration.parameter.DailyJobParameter;
 import com.yachaerang.yachaerangbatch.domain.dailyPrice.processor.DailyPriceProcessor;
 import com.yachaerang.yachaerangbatch.domain.dailyPrice.reader.DailyPriceReader;
 import com.yachaerang.yachaerangbatch.domain.dailyPrice.writer.DailyPriceWriter;
@@ -14,12 +15,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.builder.StepBuilder;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -34,7 +38,7 @@ Daily Price Job에 대한 설정
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
-public class DailyPriceJobConfig {
+public class DailyPriceJobConfig implements Tasklet {
 
     private final JobRepository jobRepository;
     private final PlatformTransactionManager platformTransactionManager;
@@ -78,15 +82,14 @@ public class DailyPriceJobConfig {
 
     /**
      * Reader 스텝
-     * @param targetDateStr : jobParameters에서 얻어오기
+     * @param dailyJobParameter : jobParameters에서 얻어오기
      * @return
      */
     @Bean
     @StepScope
-    public DailyPriceReader dailyPriceReader(
-            @Value("#{jobParameters['targetDate']}") String targetDateStr) {
+    public DailyPriceReader dailyPriceReader(DailyJobParameter dailyJobParameter) {
 
-        LocalDate targetDate = parseTargetDate(targetDateStr);
+        LocalDate targetDate = dailyJobParameter.getTargetDate();
 
         log.info("Reader 생성: targetDate={}", targetDate);
 
@@ -95,15 +98,14 @@ public class DailyPriceJobConfig {
 
     /**
      * Processor Step
-     * @param targetDateStr : jobParameter로부터 얻음 (category는 reader에서 필터링)
+     * @param dailyJobParameter : jobParameter로부터 얻음 (category는 reader에서 필터링)
      * @return
      */
     @Bean
     @StepScope
-    public DailyPriceProcessor dailyPriceProcessor(
-            @Value("#{jobParameters['targetDate']}") String targetDateStr) {
+    public DailyPriceProcessor dailyPriceProcessor(DailyJobParameter dailyJobParameter) {
 
-        LocalDate targetDate = parseTargetDate(targetDateStr);
+        LocalDate targetDate = dailyJobParameter.getTargetDate();
 
         return new DailyPriceProcessor(
                 productRepository,
@@ -128,5 +130,10 @@ public class DailyPriceJobConfig {
             return LocalDate.now().minusDays(1);
         }
         return LocalDate.parse(targetDateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        return null;
     }
 }

--- a/src/main/java/com/yachaerang/yachaerangbatch/configuration/job/DailyPriceJobConfig.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/configuration/job/DailyPriceJobConfig.java
@@ -38,7 +38,7 @@ Daily Price Job에 대한 설정
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
-public class DailyPriceJobConfig implements Tasklet {
+public class DailyPriceJobConfig {
 
     private final JobRepository jobRepository;
     private final PlatformTransactionManager platformTransactionManager;
@@ -130,10 +130,5 @@ public class DailyPriceJobConfig implements Tasklet {
             return LocalDate.now().minusDays(1);
         }
         return LocalDate.parse(targetDateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-    }
-
-    @Override
-    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
-        return null;
     }
 }

--- a/src/main/java/com/yachaerang/yachaerangbatch/configuration/job/MonthlyPriceJobConfig.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/configuration/job/MonthlyPriceJobConfig.java
@@ -1,4 +1,123 @@
 package com.yachaerang.yachaerangbatch.configuration.job;
 
+import com.yachaerang.yachaerangbatch.domain.entity.MonthlyPrice;
+import com.yachaerang.yachaerangbatch.listener.JobCompletionListener;
+import com.yachaerang.yachaerangbatch.listener.StepExecutionListener;
+import com.yachaerang.yachaerangbatch.service.MonthlyPriceAggregationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.support.ListItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
 public class MonthlyPriceJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager platformTransactionManager;
+    private final JobCompletionListener jobCompletionListener;
+    private final StepExecutionListener stepExecutionListener;
+
+    private final MonthlyPriceAggregationService monthlyPriceAggregationService;
+
+
+    private static final int CHUNK_SIZE= 100;
+
+    @Bean
+    public Job monthlyPriceJob(Step monthlyPriceStep) {
+        return new JobBuilder("monthlyPriceJob", jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .listener(jobCompletionListener)
+                .start(monthlyPriceStep)
+                .build();
+    }
+
+    /*
+    MonthlyPrice Step
+     */
+    @Bean
+    public Step monthlyPriceStep(
+            ListItemReader<MonthlyPrice> monthlyPriceReader,
+            ItemProcessor<MonthlyPrice, MonthlyPrice> monthlyPriceProcessor,
+            ItemWriter<MonthlyPrice> monthlyPriceWriter
+    ) {
+        return new StepBuilder("monthlyPriceStep", jobRepository)
+                .<MonthlyPrice, MonthlyPrice>chunk(CHUNK_SIZE, platformTransactionManager)
+                .listener(stepExecutionListener)
+                .reader(monthlyPriceReader)
+                .processor(monthlyPriceProcessor)
+                .writer(monthlyPriceWriter)
+                .faultTolerant()
+                .retryLimit(3)
+                .retry(Exception.class)
+                .build();
+    }
+
+    /**
+     * Reader 스텝
+     * @param year : 대상 년도
+     * @param month : 대상 월
+     * @return
+     */
+    @Bean
+    @StepScope
+    public ListItemReader<MonthlyPrice> monthlyPriceReader(
+            @Value("#{jobParameters['year']}") String year,
+            @Value("#{jobParameters['month']}") String month
+    ) {
+        int y = Integer.parseInt(year);
+        int m = Integer.parseInt(month);
+
+        List<MonthlyPrice> monthlyPriceList =
+                monthlyPriceAggregationService.getMonthlyAggregatedPrices(y, m);
+
+        log.info("ListItemReader 초기화 - 최종 리스트 크기: {}", monthlyPriceList.size());
+        return new ListItemReader<>(monthlyPriceList);
+    }
+
+    /**
+     * Processor Step
+     * @return
+     */
+    @Bean
+    public ItemProcessor<MonthlyPrice, MonthlyPrice> monthlyPriceProcessor() {
+        return item -> {
+            if (item.getPriceCount() == 0) {
+                log.debug("priceCount가 0이므로 스킵: {}", item.getProductCode());
+                return null;
+            }
+            return item;
+        };
+    }
+
+    /**
+     * Writer 스텝
+     * 집계 서비스를 통해 대신 MyBatis 실행
+     * @return
+     */
+    @Bean
+    public ItemWriter<MonthlyPrice> monthlyPriceWriter() {
+        return chunk -> {
+            List<MonthlyPrice> items = new ArrayList<>(chunk.getItems());
+            log.info("저장할 데이터 : {} 건", items.size());
+            monthlyPriceAggregationService.saveMonthlyPrices(items);
+        };
+    }
 }

--- a/src/main/java/com/yachaerang/yachaerangbatch/configuration/job/MonthlyPriceJobConfig.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/configuration/job/MonthlyPriceJobConfig.java
@@ -1,5 +1,6 @@
 package com.yachaerang.yachaerangbatch.configuration.job;
 
+import com.yachaerang.yachaerangbatch.configuration.parameter.MonthlyJobParameter;
 import com.yachaerang.yachaerangbatch.domain.entity.MonthlyPrice;
 import com.yachaerang.yachaerangbatch.listener.JobCompletionListener;
 import com.yachaerang.yachaerangbatch.listener.StepExecutionListener;
@@ -16,7 +17,6 @@ import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.support.ListItemReader;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -72,21 +72,17 @@ public class MonthlyPriceJobConfig {
 
     /**
      * Reader 스텝
-     * @param year : 대상 년도
-     * @param month : 대상 월
+     * @param monthlyJobParameter: 연도와 월
      * @return
      */
     @Bean
     @StepScope
-    public ListItemReader<MonthlyPrice> monthlyPriceReader(
-            @Value("#{jobParameters['year']}") String year,
-            @Value("#{jobParameters['month']}") String month
-    ) {
-        int y = Integer.parseInt(year);
-        int m = Integer.parseInt(month);
+    public ListItemReader<MonthlyPrice> monthlyPriceReader(MonthlyJobParameter monthlyJobParameter) {
+        int year = monthlyJobParameter.getYear();
+        int month = monthlyJobParameter.getMonth();
 
         List<MonthlyPrice> monthlyPriceList =
-                monthlyPriceAggregationService.getMonthlyAggregatedPrices(y, m);
+                monthlyPriceAggregationService.getMonthlyAggregatedPrices(year, month);
 
         log.info("ListItemReader 초기화 - 최종 리스트 크기: {}", monthlyPriceList.size());
         return new ListItemReader<>(monthlyPriceList);

--- a/src/main/java/com/yachaerang/yachaerangbatch/configuration/job/WeeklyPriceJobConfig.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/configuration/job/WeeklyPriceJobConfig.java
@@ -3,7 +3,7 @@ package com.yachaerang.yachaerangbatch.configuration.job;
 import com.yachaerang.yachaerangbatch.domain.entity.WeeklyPrice;
 import com.yachaerang.yachaerangbatch.listener.JobCompletionListener;
 import com.yachaerang.yachaerangbatch.listener.StepExecutionListener;
-import com.yachaerang.yachaerangbatch.service.PriceAggregationService;
+import com.yachaerang.yachaerangbatch.service.WeeklyPriceAggregationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.*;
@@ -34,7 +34,7 @@ public class WeeklyPriceJobConfig {
     private final JobCompletionListener jobCompletionListener;
     private final StepExecutionListener stepExecutionListener;
 
-    private final PriceAggregationService priceAggregationService;
+    private final WeeklyPriceAggregationService weeklyPriceAggregationService;
 
     private static final int CHUNK_SIZE= 100;
 
@@ -77,7 +77,7 @@ public class WeeklyPriceJobConfig {
             @Value("#{jobParameters['endDate']}") String endDate) {
 
         List<WeeklyPrice> weeklyPriceList =
-                priceAggregationService.getWeeklyAggregatedPrices(
+                weeklyPriceAggregationService.getWeeklyAggregatedPrices(
                         LocalDate.parse(startDate), LocalDate.parse(endDate)
                 );
 
@@ -112,7 +112,7 @@ public class WeeklyPriceJobConfig {
         return chunk -> {
             List<WeeklyPrice> items = new ArrayList<>(chunk.getItems());
             log.info("저장할 데이터 : {} 건", items.size());
-            priceAggregationService.saveWeeklyPrices(items);
+            weeklyPriceAggregationService.saveWeeklyPrices(items);
         };
     }
 }

--- a/src/main/java/com/yachaerang/yachaerangbatch/configuration/job/YearlyPriceJobConfig.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/configuration/job/YearlyPriceJobConfig.java
@@ -1,4 +1,127 @@
 package com.yachaerang.yachaerangbatch.configuration.job;
 
+import com.yachaerang.yachaerangbatch.domain.entity.YearlyPrice;
+import com.yachaerang.yachaerangbatch.listener.JobCompletionListener;
+import com.yachaerang.yachaerangbatch.listener.StepExecutionListener;
+import com.yachaerang.yachaerangbatch.service.YearlyPriceAggregationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.support.ListItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
 public class YearlyPriceJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager platformTransactionManager;
+    private final JobCompletionListener jobCompletionListener;
+    private final StepExecutionListener stepExecutionListener;
+
+    private final YearlyPriceAggregationService yearlyPriceAggregationService;
+
+    private static final int CHUNK_SIZE = 100;
+
+    @Bean
+    public Job yearlyPriceJob(Step yearlyPriceStep) {
+        return new JobBuilder("yearlyPriceJob", jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .listener(jobCompletionListener)
+                .start(yearlyPriceStep)
+                .build();
+    }
+
+    /*
+    YearlyPrice Step
+     */
+    @Bean
+    public Step yearlyPriceStep(
+            ListItemReader<YearlyPrice> yearlyPriceReader,
+            ItemProcessor<YearlyPrice, YearlyPrice> yearlyPriceProcessor,
+            ItemWriter<YearlyPrice> yearlyPriceWriter
+    ) {
+        return new StepBuilder("yearlyPriceStep", jobRepository)
+                .<YearlyPrice, YearlyPrice>chunk(CHUNK_SIZE, platformTransactionManager)
+                .listener(stepExecutionListener)
+                .reader(yearlyPriceReader)
+                .processor(yearlyPriceProcessor)
+                .writer(yearlyPriceWriter)
+                .faultTolerant()
+                .retryLimit(3)
+                .retry(Exception.class)
+                .build();
+    }
+
+    /**
+     * Reader 스텝
+     * @param year : 대상 년도
+     * @return
+     */
+    @Bean
+    @StepScope
+    public ListItemReader<YearlyPrice> yearlyPriceReader(
+            @Value("#{jobParameters['year']}") String year
+    ) {
+        int y = Integer.parseInt(year);
+
+        List<YearlyPrice> yearlyPriceList =
+                yearlyPriceAggregationService.getYearlyAggregatedPrices(y);
+
+        log.info("ListItemReader 초기화 - 최종 리스트 크기: {}", yearlyPriceList.size());
+        return new ListItemReader<>(yearlyPriceList);
+    }
+
+    /**
+     * Processor Step : start_price, end_price 설정해 저장
+     * @return
+     */
+    @Bean
+    @StepScope
+    public ItemProcessor<YearlyPrice, YearlyPrice> yearlyPriceProcessor(
+            @Value("#{jobParameters['year']}") String year
+    ) {
+        int y = Integer.parseInt(year);
+
+        return item -> {
+            if (item.getPriceCount() == 0) {
+                log.debug("priceCount가 0이므로 스킵: {}", item.getProductCode());
+                return null;
+            }
+
+            // 연초와 연말 가격 설정
+            item.setStartPrice(yearlyPriceAggregationService.getStartPrice(item.getProductCode(), y));
+            item.setEndPrice(yearlyPriceAggregationService.getEndPrice(item.getProductCode(), y));
+            return item;
+        };
+    }
+
+    /**
+     * Writer 스텝
+     *
+     * @return
+     */
+    @Bean
+    public ItemWriter<YearlyPrice> yearlyPriceWriter() {
+        return chunk -> {
+            List<YearlyPrice> items = new ArrayList<>(chunk.getItems());
+            log.info("저장할 데이터 : {} 건", items.size());
+            yearlyPriceAggregationService.saveYearlyPrices(items);
+        };
+    }
 }

--- a/src/main/java/com/yachaerang/yachaerangbatch/configuration/job/YearlyPriceJobConfig.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/configuration/job/YearlyPriceJobConfig.java
@@ -1,5 +1,6 @@
 package com.yachaerang.yachaerangbatch.configuration.job;
 
+import com.yachaerang.yachaerangbatch.configuration.parameter.MonthlyJobParameter;
 import com.yachaerang.yachaerangbatch.domain.entity.YearlyPrice;
 import com.yachaerang.yachaerangbatch.listener.JobCompletionListener;
 import com.yachaerang.yachaerangbatch.listener.StepExecutionListener;
@@ -93,10 +94,8 @@ public class YearlyPriceJobConfig {
      */
     @Bean
     @StepScope
-    public ItemProcessor<YearlyPrice, YearlyPrice> yearlyPriceProcessor(
-            @Value("#{jobParameters['year']}") String year
-    ) {
-        int y = Integer.parseInt(year);
+    public ItemProcessor<YearlyPrice, YearlyPrice> yearlyPriceProcessor(MonthlyJobParameter monthlyJobParameter) {
+        int year = monthlyJobParameter.getYear();
 
         return item -> {
             if (item.getPriceCount() == 0) {
@@ -105,8 +104,8 @@ public class YearlyPriceJobConfig {
             }
 
             // 연초와 연말 가격 설정
-            item.setStartPrice(yearlyPriceAggregationService.getStartPrice(item.getProductCode(), y));
-            item.setEndPrice(yearlyPriceAggregationService.getEndPrice(item.getProductCode(), y));
+            item.setStartPrice(yearlyPriceAggregationService.getStartPrice(item.getProductCode(), year));
+            item.setEndPrice(yearlyPriceAggregationService.getEndPrice(item.getProductCode(), year));
             return item;
         };
     }

--- a/src/main/java/com/yachaerang/yachaerangbatch/configuration/parameter/DailyJobParameter.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/configuration/parameter/DailyJobParameter.java
@@ -1,4 +1,4 @@
-package com.yachaerang.yachaerangbatch.configuration.parmameter;
+package com.yachaerang.yachaerangbatch.configuration.parameter;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/yachaerang/yachaerangbatch/configuration/parameter/DailyJobParameter.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/configuration/parameter/DailyJobParameter.java
@@ -2,13 +2,17 @@ package com.yachaerang.yachaerangbatch.configuration.parameter;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.JobScope;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 @Slf4j
 @Getter
+@JobScope
+@Component
 public class DailyJobParameter {
 
     private LocalDate targetDate;

--- a/src/main/java/com/yachaerang/yachaerangbatch/configuration/parameter/MonthlyJobParameter.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/configuration/parameter/MonthlyJobParameter.java
@@ -2,12 +2,16 @@ package com.yachaerang.yachaerangbatch.configuration.parameter;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.JobScope;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 
 @Slf4j
 @Getter
+@Component
+@JobScope
 public class MonthlyJobParameter {
 
     private Integer year;

--- a/src/main/java/com/yachaerang/yachaerangbatch/configuration/parameter/MonthlyJobParameter.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/configuration/parameter/MonthlyJobParameter.java
@@ -1,4 +1,4 @@
-package com.yachaerang.yachaerangbatch.configuration.parmameter;
+package com.yachaerang.yachaerangbatch.configuration.parameter;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/yachaerang/yachaerangbatch/configuration/parmameter/MonthlyJobParameter.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/configuration/parmameter/MonthlyJobParameter.java
@@ -1,0 +1,79 @@
+package com.yachaerang.yachaerangbatch.configuration.parmameter;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Getter
+public class MonthlyJobParameter {
+
+    private Integer year;
+    private Integer month;
+
+    /*
+    year 설정
+     */
+    @Value("#{jobParameters['year']}")
+    public void setYear(String year) {
+        if (year == null || year.isBlank()) {
+            int defaultYear = LocalDate.now().getYear();
+            this.year = defaultYear;
+            log.info("jobParameters['year'] 미입력 → 기본값 사용: {}", this.year);
+            return;
+        }
+
+        int parsed = parseIntOrThrow("year", year);
+        validateYear(parsed);
+        this.year = parsed;
+
+        log.info("Target Year 설정: {}", this.year);
+    }
+
+    /*
+    month 설정하기
+     */
+    @Value("#{jobParameters['month']}")
+    public void setMonth(String month) {
+        if (month == null || month.isBlank()) {
+            int defaultMonth = LocalDate.now().getMonthValue();
+            this.month = defaultMonth;
+            log.info("jobParameters['month'] 미입력 → 기본값 사용: {}", this.month);
+            return;
+        }
+
+        int parsed = parseIntOrThrow("month", month);
+        this.month = normalizeMonth(parsed);
+
+        log.info("Target Month 설정: {}", this.month);
+    }
+
+
+    private int parseIntOrThrow(String key, String raw) {
+        try {
+            return Integer.parseInt(raw.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("jobParameters['" + key + "']는 숫자여야 합니다. 입력값=" + raw, e);
+        }
+    }
+
+    /*
+    Year Validation 확인
+    */
+    private void validateYear(int year) {
+        if (year < 1900 || year > 3000) {
+            throw new IllegalArgumentException("year 범위가 올바르지 않습니다: " + year);
+        }
+    }
+
+    /*
+    Month Validation 확인
+     */
+    private int normalizeMonth(int month) {
+        int m = month % 12;
+        if (m <= 0) m += 12;
+        return m;
+    }
+}

--- a/src/main/java/com/yachaerang/yachaerangbatch/controller/BatchJobController.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/controller/BatchJobController.java
@@ -4,6 +4,7 @@ import com.yachaerang.yachaerangbatch.scheduler.DailyPriceScheduler;
 import com.yachaerang.yachaerangbatch.service.BatchJobService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionException;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -112,5 +113,29 @@ public class BatchJobController {
 
         batchJobService.runWeeklyAggregation(targetDate);
         return ResponseEntity.ok("Job 실행 시작");
+    }
+
+    /*
+    특정 월의 월간 집계 데이터 구하기
+     */
+    @PostMapping("/monthly-price")
+    public ResponseEntity<String> runMonthlyPriceJob(
+            @RequestParam Integer year, @RequestParam Integer month
+    ) throws JobExecutionException {
+        batchJobService.runMonthlyAggregation(year, month);
+        return ResponseEntity.ok("Job 실행 시작");
+    }
+
+    /*
+    특정 년도의 연간 데이터 구하기
+     */
+    @PostMapping("/yearly-price")
+    public ResponseEntity<String> runYearlyPriceJob(
+            @RequestParam Integer year
+    ) {
+        batchJobService.runYearlyAggregation(year);
+        return ResponseEntity.ok(
+                String.format("연간 가격 집계 완료 - %d년", year)
+        );
     }
 }

--- a/src/main/java/com/yachaerang/yachaerangbatch/domain/entity/MonthlyPrice.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/domain/entity/MonthlyPrice.java
@@ -18,11 +18,11 @@ public class MonthlyPrice extends BaseEntity {
     private String productCode;
 
     private Integer priceYear;
+    private Integer priceMonth;
 
     private Double avgPrice;
     private Long minPrice;
     private Long maxPrice;
 
-    private Long startPrice;
-    private Long endPrice;
+    private Integer priceCount;
 }

--- a/src/main/java/com/yachaerang/yachaerangbatch/domain/entity/YearlyPrice.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/domain/entity/YearlyPrice.java
@@ -16,11 +16,12 @@ public class YearlyPrice extends BaseEntity {
     private String productCode;
 
     private Integer priceYear;
-    private Integer priceMonth;
 
     private Double avgPrice;
     private Long minPrice;
     private Long maxPrice;
+    private Long startPrice;
+    private Long endPrice;
 
     private Integer priceCount;
 }

--- a/src/main/java/com/yachaerang/yachaerangbatch/repository/MonthlyPriceRepository.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/repository/MonthlyPriceRepository.java
@@ -1,4 +1,33 @@
 package com.yachaerang.yachaerangbatch.repository;
 
+import com.yachaerang.yachaerangbatch.domain.entity.MonthlyPrice;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Mapper
 public interface MonthlyPriceRepository {
+
+    /**
+     * 시작일~종료일을 기준으로 한달 집계에 대하여 조회
+     * @param startDate : 시작일(서비스 코드에서 한달의 시작으로 조정)
+     * @param endDate : 종료일(서비스 코드에서 한달의 종료일로 조정)
+     * @return
+     */
+    List<MonthlyPrice> selectMonthlyAggregatedPrices(
+            @Param("startDate")LocalDate startDate,
+            @Param("endDate")LocalDate endDate
+            );
+
+    /*
+    한달에 대한 가격 저장
+     */
+    void upsertMonthlyPrice(MonthlyPrice monthlyPrice);
+
+    /*
+    배치 저장
+     */
+    void batchUpsertMonthlyPrice(List<MonthlyPrice> monthlyPrices);
 }

--- a/src/main/java/com/yachaerang/yachaerangbatch/repository/YearlyPriceRepository.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/repository/YearlyPriceRepository.java
@@ -1,4 +1,37 @@
 package com.yachaerang.yachaerangbatch.repository;
 
+import com.yachaerang.yachaerangbatch.domain.entity.YearlyPrice;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
 public interface YearlyPriceRepository {
+
+    /*
+    일별 데이터를 연간으로 집계하여 조회
+     */
+    List<YearlyPrice> selectYearlyAggregatedPrices(@Param("targetYear") Integer targetYear);
+
+    /**
+     * 연초 가격 조회
+     */
+    Long selectStartPrice(
+            @Param("productCode") String productCode,
+            @Param("targetYear") Integer targetYear
+    );
+
+    /**
+     * 연말 가격 조회
+     */
+    Long selectEndPrice(
+            @Param("productCode") String productCode,
+            @Param("targetYear") Integer targetYear
+    );
+
+    /*
+    연간 가격 데이터 저장
+     */
+    int upsertYearlyPrice(YearlyPrice yearlyPrice);
 }

--- a/src/main/java/com/yachaerang/yachaerangbatch/scheduler/MonthlyPriceScheduler.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/scheduler/MonthlyPriceScheduler.java
@@ -9,6 +9,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 
 @Slf4j
 @Component
@@ -18,12 +19,12 @@ public class MonthlyPriceScheduler {
     private final BatchJobService batchJobService;
 
     /**
-     * 매월 1일 새벽 2시에 전월 데이터 수집
+     * 매월 1일 새벽 2시에 전월의 일간 데이터 수집
      */
     @Scheduled(cron = "0 0 2 1 * *")
     public void collectPreviousMonthData() {
         log.info("========================================");
-        log.info("월간 배치 스케줄러 시작: {}", LocalDateTime.now());
+        log.info("지난 달의 일간 배치 스케줄러 시작: {}", LocalDateTime.now());
         log.info("========================================");
 
         try {
@@ -36,6 +37,24 @@ public class MonthlyPriceScheduler {
                     log.error("카테고리 {} 수집 실패: {}", category, e.getMessage());
                 }
             }
+            log.info("지난 달의 일간 배치 스케줄러 완료");
+        } catch (Exception e) {
+            log.error("지난 달의 일간 배치 스케줄러 실패", e);
+        }
+    }
+
+    /**
+     * 매월 1일 새벽 3시에 전월의 월간 데이터 수집
+     */
+    @Scheduled(cron = "0 0 3 1 * *")
+    public void runLastMonthAggregation() {
+        log.info("========================================");
+        log.info("월간 배치 스케줄러 시작: {}", YearMonth.now().minusMonths(1));
+        log.info("========================================");
+
+        try {
+            YearMonth lastMonth = YearMonth.now().minusMonths(1);
+            batchJobService.runMonthlyAggregation(lastMonth.getYear(), lastMonth.getMonthValue());
             log.info("월간 배치 스케줄러 완료");
         } catch (Exception e) {
             log.error("월간 배치 스케줄러 실패", e);

--- a/src/main/java/com/yachaerang/yachaerangbatch/service/BatchJobService.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/service/BatchJobService.java
@@ -1,9 +1,11 @@
 package com.yachaerang.yachaerangbatch.service;
 
+import com.yachaerang.yachaerangbatch.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.*;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
 import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
@@ -20,6 +22,8 @@ public class BatchJobService {
     private final Job dateRangePriceJob;
     private final Job dailyPriceJob;
     private final Job weeklyPriceJob;
+    private final Job monthlyPriceJob;
+    private final Job yearlyPriceJob;
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
@@ -73,7 +77,7 @@ public class BatchJobService {
     }
 
     /**
-     * 전월 데이터 수집
+     * 전월 일간 데이터 수집
      */
     public JobExecution collectPreviousMonth() throws JobExecutionException {
         YearMonth previousMonth = YearMonth.now().minusMonths(1);
@@ -109,6 +113,90 @@ public class BatchJobService {
         } catch (Exception e) {
             log.error("주간 가격 집계 Job 실행 실패", e);
             throw new RuntimeException("Job 실행 실패", e);
+        }
+    }
+
+    /**
+     * 특정 기간의 월간 가격 집계 실행
+     */
+    public void runMonthlyAggregation(Integer year, Integer month) throws JobExecutionException {
+        // 날짜 검증
+        if (year == null || month == null) {
+            throw new GeneralException("year와 month는 필수입니다.");
+        }
+        if (month < 1 || month >12) {
+            throw new GeneralException("month는 1~12 사이여야합니다.");
+        }
+        YearMonth targetMonth = YearMonth.of(year, month);
+        YearMonth currentMonth = YearMonth.now();
+        if (!targetMonth.isBefore(currentMonth)) {
+            throw new GeneralException(
+                    String.format("아직 완료되지 않은 달입니다. 대상: {}년 {}월", year, month)
+            );
+        }
+
+        log.info("월간 집계 실행 - 대상: {}년 {}월", year, month);
+
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addString("year", year.toString())
+                    .addString("month", month.toString())
+                    .addLong("timestamp", System.currentTimeMillis())
+                    .toJobParameters();
+
+            JobExecution execution = jobLauncher.run(monthlyPriceJob, params);
+            log.info("Job 실행 결과: {}", execution.getStatus());
+
+            if (execution.getStatus() == BatchStatus.FAILED) {
+                throw new GeneralException("월간 집계 Job이 실패했습니다.");
+            }
+        } catch (JobExecutionAlreadyRunningException e) {
+            log.warn("이미 실행 중인 Job입니다.");
+            throw new GeneralException("이미 실행 중인 Job입니다.", e);
+        } catch (Exception e) {
+            log.error("월간 가격 집계 Job 실행 실패", e);
+            throw new GeneralException("Job 실행 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 특정 연도의 연간 가격 집계 실행
+     */
+    public void runYearlyAggregation(Integer year) {
+        // 기본 유효성 검증
+        if (year == null) {
+            throw new IllegalArgumentException("year는 필수입니다.");
+        }
+
+        // 미완료 연도 검증
+        int currentYear = LocalDate.now().getYear();
+        if (year >= currentYear) {
+            throw new IllegalArgumentException(
+                    String.format("아직 완료되지 않은 연도입니다. 대상: %d년", year)
+            );
+        }
+
+        log.info("연간 집계 실행 - 대상: {}년", year);
+
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addString("year", year.toString())
+                    .addLong("timestamp", System.currentTimeMillis())
+                    .toJobParameters();
+
+            JobExecution execution = jobLauncher.run(yearlyPriceJob, params);
+            log.info("Job 실행 결과: {}", execution.getStatus());
+
+            if (execution.getStatus() == BatchStatus.FAILED) {
+                throw new GeneralException("연간 집계 Job이 실패했습니다.");
+            }
+
+        } catch (JobExecutionAlreadyRunningException e) {
+            log.warn("이미 실행 중인 Job입니다.");
+            throw new RuntimeException("이미 실행 중인 Job입니다.", e);
+        } catch (Exception e) {
+            log.error("연간 가격 집계 Job 실행 실패", e);
+            throw new RuntimeException("Job 실행 실패: " + e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/com/yachaerang/yachaerangbatch/service/BatchJobService.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/service/BatchJobService.java
@@ -131,7 +131,7 @@ public class BatchJobService {
         YearMonth currentMonth = YearMonth.now();
         if (!targetMonth.isBefore(currentMonth)) {
             throw new GeneralException(
-                    String.format("아직 완료되지 않은 달입니다. 대상: {}년 {}월", year, month)
+                    String.format("아직 완료되지 않은 달입니다. 대상: %d년 %d월", year, month)
             );
         }
 

--- a/src/main/java/com/yachaerang/yachaerangbatch/service/MonthlyPriceAggregationService.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/service/MonthlyPriceAggregationService.java
@@ -1,0 +1,56 @@
+package com.yachaerang.yachaerangbatch.service;
+
+import com.yachaerang.yachaerangbatch.domain.entity.MonthlyPrice;
+import com.yachaerang.yachaerangbatch.repository.MonthlyPriceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class MonthlyPriceAggregationService {
+
+    private final MonthlyPriceRepository monthlyPriceRepository;
+
+    /**
+     * 월간 집계 데이터 조회
+     */
+    public List<MonthlyPrice> getMonthlyAggregatedPrices(int year, int month) {
+        log.info("월간 집계 데이터 조회 - 기간: {}년 {}월", year, month);
+
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = LocalDate.of(year, month, 1)
+                .with(TemporalAdjusters.lastDayOfMonth());
+
+        List<MonthlyPrice> results = monthlyPriceRepository.selectMonthlyAggregatedPrices(startDate, endDate);
+
+        log.info("조회된 집계 데이터: {} 건", results.size());
+        return results;
+    }
+
+    /**
+     * 월간 가격 데이터 저장
+     */
+    public void saveMonthlyPrices(MonthlyPrice monthlyPrice) {
+        monthlyPriceRepository.upsertMonthlyPrice(monthlyPrice);
+    }
+
+    /**
+     * 월간 가격 데이터 배치 저장
+     */
+    public void saveMonthlyPrices(List<MonthlyPrice> monthlyPrices) {
+        if (monthlyPrices == null || monthlyPrices.isEmpty()) {
+            log.info("저장할 데이터가 없습니다.");
+            return;
+        }
+        monthlyPriceRepository.batchUpsertMonthlyPrice(monthlyPrices);
+        log.info("{} 건 저장 완료",  monthlyPrices.size());
+    }
+}

--- a/src/main/java/com/yachaerang/yachaerangbatch/service/WeeklyPriceAggregationService.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/service/WeeklyPriceAggregationService.java
@@ -17,7 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 @Transactional
-public class PriceAggregationService {
+public class WeeklyPriceAggregationService {
 
     private final WeeklyPriceRepository weeklyPriceRepository;
 

--- a/src/main/java/com/yachaerang/yachaerangbatch/service/YearlyPriceAggregationService.java
+++ b/src/main/java/com/yachaerang/yachaerangbatch/service/YearlyPriceAggregationService.java
@@ -1,0 +1,55 @@
+package com.yachaerang.yachaerangbatch.service;
+
+import com.yachaerang.yachaerangbatch.domain.entity.YearlyPrice;
+import com.yachaerang.yachaerangbatch.repository.YearlyPriceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class YearlyPriceAggregationService {
+
+    private final YearlyPriceRepository yearlyPriceRepository;
+
+    /**
+     * 연간 집계 데이터 조회
+     */
+    public List<YearlyPrice> getYearlyAggregatedPrices(int year) {
+        log.info("연간 집계 데이터 조회 - 연도: {}", year);
+
+        List<YearlyPrice> result = yearlyPriceRepository.selectYearlyAggregatedPrices(year);
+        log.info("조회된 집계 데이터: {} 건", result.size());
+
+        return result;
+    }
+
+    /**
+     * 연초 가격 조회
+     */
+    public Long getStartPrice(String productCode, int year) {
+        return yearlyPriceRepository.selectStartPrice(productCode, year);
+    }
+
+    /**
+     * 연말 가격 조회
+     */
+    public Long getEndPrice(String productCode, int year) {
+        return yearlyPriceRepository.selectEndPrice(productCode, year);
+    }
+
+    /**
+     * 연간 가격 데이터 저장
+     */
+    @Transactional
+    public void saveYearlyPrices(List<YearlyPrice> yearlyPrices) {
+        for (YearlyPrice yearlyPrice : yearlyPrices) {
+            yearlyPriceRepository.upsertYearlyPrice(yearlyPrice);
+        }
+        log.info("{} 건 저장 완료", yearlyPrices.size());
+    }
+}

--- a/src/main/resources/mappers/monthly_price-mappers.xml
+++ b/src/main/resources/mappers/monthly_price-mappers.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.yachaerang.yachaerangbatch.repository.MonthlyPriceRepository">
+    <resultMap id="monthlyPriceResultMap"
+               type="com.yachaerang.yachaerangbatch.domain.entity.MonthlyPrice">
+        <id property="monthlyPriceId" column="monthly_price_id"/>
+        <result property="productCode" column="product_code"/>
+        <result property="priceYear" column="price_year"/>
+        <result property="priceMonth" column="price_month"/>
+        <result property="avgPrice" column="avg_price"/>
+        <result property="minPrice" column="min_price"/>
+        <result property="maxPrice" column="max_price"/>
+        <result property="priceCount" column="price_count"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+    </resultMap>
+    <!-- 일별 데이터를 월간으로 집계 -->
+    <select id="selectMonthlyAggregatedPrices" resultMap="monthlyPriceResultMap">
+        SELECT
+            dp.product_code AS product_code,
+            YEAR(dp.price_date) AS price_year,
+            MONTH(dp.price_date) AS price_month,
+            ROUND(AVG(dp.price), 2) AS avg_price,
+            MIN(dp.price) AS min_price,
+            MAX(dp.price) AS max_price,
+            COUNT(*) AS price_count
+        FROM daily_price dp
+        WHERE dp.price_date BETWEEN #{startDate} AND #{endDate}
+        GROUP BY dp.product_code, YEAR(dp.price_date), MONTH(dp.price_date)
+        ORDER BY dp.product_code, price_year, price_month
+    </select>
+
+    <!-- 월별 가격 데이터 -->
+    <insert id="upsertMonthlyPrice" parameterType="com.yachaerang.yachaerangbatch.domain.entity.MonthlyPrice">
+        INSERT INTO monthly_price (
+            product_code, price_year, price_month,
+            avg_price, min_price, max_price, price_count
+        ) VALUES (
+                     #{productCode}, #{priceYear}, #{priceMonth},
+                     #{avgPrice}, #{minPrice}, #{maxPrice}, #{priceCount}
+                 )
+            ON DUPLICATE KEY UPDATE
+                                 avg_price = VALUES(avg_price),
+                                 min_price = VALUES(min_price),
+                                 max_price = VALUES(max_price),
+                                 price_count = VALUES(price_count),
+                                 updated_at = CURRENT_TIMESTAMP
+    </insert>
+
+    <!-- 배치 저장 -->
+    <insert id="batchUpsertMonthlyPrice" parameterType="list">
+        INSERT INTO monthly_price (
+            product_code, price_year, price_month,
+            avg_price, min_price, max_price, price_count
+        ) VALUES
+            <foreach collection="list" item="item" separator=",">
+                (
+                #{item.productCode}, #{item.priceYear}, #{item.priceMonth},
+                #{item.avgPrice}, #{item.minPrice}, #{item.maxPrice}, #{item.priceCount}
+                )
+            </foreach>
+        ON DUPLICATE KEY UPDATE
+        avg_price = VALUES(avg_price),
+        min_price = VALUES(min_price),
+        max_price = VALUES(max_price),
+        price_count = VALUES(price_count),
+        updated_at = CURRENT_TIMESTAMP
+    </insert>
+</mapper>

--- a/src/main/resources/mappers/yearly_price-mappers.xml
+++ b/src/main/resources/mappers/yearly_price-mappers.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.yachaerang.yachaerangbatch.repository.YearlyPriceRepository">
+    <resultMap id="yearlyPriceResultMap"
+               type="com.yachaerang.yachaerangbatch.domain.entity.YearlyPrice">
+        <id property="yearlyPriceId" column="yearly_price_id"/>
+        <result property="productCode" column="product_code"/>
+        <result property="priceYear" column="price_year"/>
+        <result property="avgPrice" column="avg_price"/>
+        <result property="minPrice" column="min_price"/>
+        <result property="maxPrice" column="max_price"/>
+        <result property="startPrice" column="start_price"/>
+        <result property="endPrice" column="end_price"/>
+        <result property="priceCount" column="price_count"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+    </resultMap>
+
+    <!-- 일별 데이터를 연간으로 집계하여 조회 -->
+    <select id="selectYearlyAggregatedPrices" resultMap="yearlyPriceResultMap">
+        SELECT
+            dp.product_code AS product_code,
+            YEAR(dp.price_date) AS price_year,
+            ROUND(AVG(dp.price), 2) AS avg_price,
+            MIN(dp.price) AS min_price,
+            MAX(dp.price) AS max_price,
+            COUNT(*) AS price_count
+        FROM daily_price dp
+        WHERE YEAR(dp.price_date) = #{targetYear}
+        GROUP BY dp.product_code, YEAR(dp.price_date)
+        ORDER BY dp.product_code
+    </select>
+
+    <!-- 연초 가격 조회 (해당 연도 첫 번째 가격) -->
+    <select id="selectStartPrice" resultType="java.lang.Long">
+        SELECT dp.price
+        FROM daily_price dp
+        WHERE dp.product_code = #{productCode}
+                  AND YEAR(dp.price_date) = #{targetYear}
+        ORDER BY dp.price_date ASC
+            LIMIT 1
+    </select>
+
+    <!-- 연말 가격 조회 (해당 연도 마지막 가격) -->
+    <select id="selectEndPrice" resultType="java.lang.Long">
+        SELECT dp.price
+        FROM daily_price dp
+        WHERE dp.product_code = #{productCode}
+                  AND YEAR(dp.price_date) = #{targetYear}
+        ORDER BY dp.price_date DESC
+            LIMIT 1
+    </select>
+
+    <!-- 연간 가격 데이터 저장 (UPSERT) -->
+    <insert id="upsertYearlyPrice" parameterType="com.yachaerang.yachaerangbatch.domain.entity.YearlyPrice">
+        INSERT INTO yearly_price (
+            product_code, price_year,
+            avg_price, min_price, max_price,
+            start_price, end_price, price_count
+        ) VALUES (
+                     #{productCode}, #{priceYear},
+                     #{avgPrice}, #{minPrice}, #{maxPrice},
+                     #{startPrice}, #{endPrice}, #{priceCount}
+                 )
+            ON DUPLICATE KEY UPDATE
+                                 avg_price = VALUES(avg_price),
+                                 min_price = VALUES(min_price),
+                                 max_price = VALUES(max_price),
+                                 start_price = VALUES(start_price),
+                                 end_price = VALUES(end_price),
+                                 price_count = VALUES(price_count),
+                                 updated_at = CURRENT_TIMESTAMP
+    </insert>
+</mapper>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Close #17 

## 📝 기능 설명

- 월간 데이터 수집을 위한 `MonthlyPriceJobConfig` 생성
- 연간 데이터 수집을 위한 `YearlyPriceJobConfig` 생성
(일별 가격 데이터를 기반으로 월간 / 연간 단위의 가격 통계 데이터를 집계하고 저장하는 Batch Job을 구현)
- 각 Job은 집계 → 가공 → 저장의 동일한 흐름이고, 집계 기준(월 / 연)에 따라 파라미터와 쿼리만 분리했습니다!

<br>

## 🛠 작업 사항

- **`monthly_price-mapper.xml`**
```xml
    <select id="selectMonthlyAggregatedPrices" resultMap="monthlyPriceResultMap">
        SELECT
            dp.product_code AS product_code,
            YEAR(dp.price_date) AS price_year,
            MONTH(dp.price_date) AS price_month,
            ROUND(AVG(dp.price), 2) AS avg_price,
            MIN(dp.price) AS min_price,
            MAX(dp.price) AS max_price,
            COUNT(*) AS price_count
        FROM daily_price dp
        WHERE dp.price_date BETWEEN #{startDate} AND #{endDate}
        GROUP BY dp.product_code, YEAR(dp.price_date), MONTH(dp.price_date)
        ORDER BY dp.product_code, price_year, price_month
    </select>
```
- daily_price 테이블을 기준으로 월에 대한 통계를 집계
- YEAR, MONTH 기준으로 GROUP BY 수행
- Job 실행 시 전달받은 기간(startDate ~ endDate) 내 데이터만 조회하도록 설계

<br>

- **`MonthlyPriceJobConfig`**
```java
    /**
     * Reader 스텝
     * @param year : 대상 년도
     * @param month : 대상 월
     * @return
     */
    @Bean
    @StepScope
    public ListItemReader<MonthlyPrice> monthlyPriceReader(
            @Value("#{jobParameters['year']}") String year,
            @Value("#{jobParameters['month']}") String month
    ) {
        int y = Integer.parseInt(year);
        int m = Integer.parseInt(month);

        List<MonthlyPrice> monthlyPriceList =
                monthlyPriceAggregationService.getMonthlyAggregatedPrices(y, m);

        log.info("ListItemReader 초기화 - 최종 리스트 크기: {}", monthlyPriceList.size());
        return new ListItemReader<>(monthlyPriceList);
    }
```
- Job 파라미터로 year, month를 전달받아 월간 집계 대상 지정
- 집계 로직은 Service 계층으로 위임하여 MyBatis 로 작성을 바로 하지않고 분리함 (Job Config의 책임을 최소화, Weekly와 동일한 흐름 )

<br>

- **`yearly_price-mapper.xml`**
```xml
    <!-- 일별 데이터를 연간으로 집계하여 조회 -->
    <select id="selectYearlyAggregatedPrices" resultMap="yearlyPriceResultMap">
        SELECT
            dp.product_code AS product_code,
            YEAR(dp.price_date) AS price_year,
            ROUND(AVG(dp.price), 2) AS avg_price,
            MIN(dp.price) AS min_price,
            MAX(dp.price) AS max_price,
            COUNT(*) AS price_count
        FROM daily_price dp
        WHERE YEAR(dp.price_date) = #{targetYear}
        GROUP BY dp.product_code, YEAR(dp.price_date)
        ORDER BY dp.product_code
    </select>

    <!-- 연초 가격 조회 (해당 연도 첫 번째 가격) -->
    <select id="selectStartPrice" resultType="java.lang.Long">
        SELECT dp.price
        FROM daily_price dp
        WHERE dp.product_code = #{productCode}
                  AND YEAR(dp.price_date) = #{targetYear}
        ORDER BY dp.price_date ASC
            LIMIT 1
    </select>

    <!-- 연말 가격 조회 (해당 연도 마지막 가격) -->
    <select id="selectEndPrice" resultType="java.lang.Long">
        SELECT dp.price
        FROM daily_price dp
        WHERE dp.product_code = #{productCode}
                  AND YEAR(dp.price_date) = #{targetYear}
        ORDER BY dp.price_date DESC
            LIMIT 1
    </select>
```
- 연간 단위로 평균, 최소, 최대, 건수 집계
- 연초(start_price)와 연말(end_price) 가격은 집계 쿼리와 분리된 개별 쿼리로 조회

<br>

- **`YearlyPriceJobConfig`**
```java
    /**
     * Processor Step : start_price, end_price 설정해 저장
     * @return
     */
    @Bean
    @StepScope
    public ItemProcessor<YearlyPrice, YearlyPrice> yearlyPriceProcessor(
            @Value("#{jobParameters['year']}") String year
    ) {
        int y = Integer.parseInt(year);

        return item -> {
            if (item.getPriceCount() == 0) {
                log.debug("priceCount가 0이므로 스킵: {}", item.getProductCode());
                return null;
            }

            // 연초와 연말 가격 설정
            item.setStartPrice(yearlyPriceAggregationService.getStartPrice(item.getProductCode(), y));
            item.setEndPrice(yearlyPriceAggregationService.getEndPrice(item.getProductCode(), y));
            return item;
        };
    }
```
- Processor 단계에서 연초, 연말 가격을 추가 조회하여 모든 필드가 채워진 `YearlyPrice`가 저장 단계로 전달되도록 함
- priceCount == 0 인 데이터는 저장 대상에서 제외하여 불필요한 INSERT 방지

<br>


## ✅ 작업 항목
- [ ] 작업 1
- [ ] 작업 2

## 📎 참고 자료(선택)
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->

## 💬리뷰 요구사항(선택)

- 연간에 대한 스케줄러는 추가하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 월간/연간 가격 집계 배치와 관련 REST 엔드포인트 추가 및 매월 1일 자동 월간 집계 스케줄링 도입.

* **Refactor**
  * 배치 흐름에 장애 허용·재시도 및 단계별 처리 개선, 파라미터 처리 방식 정비로 안정성 향상.

* **Chores**
  * 월간/연간 집계용 DB 매퍼·업서트 및 배치 저장 로직 추가·보강.
  * 집계용 서비스·파라미터 헬퍼 추가로 집계 처리 및 검증 강화.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->